### PR TITLE
Implement folder deletion

### DIFF
--- a/pinax/documents/hooks.py
+++ b/pinax/documents/hooks.py
@@ -63,6 +63,21 @@ class DocumentsDefaultHookSet(object):
         """
         messages.success(request, _("Document has been deleted"))
 
+    def folder_deleted_message(self, request, folder):
+        """
+        Send messages.success message after successful document deletion.
+        """
+        messages.success(request, _("Folder has been deleted"))
+
+    def folder_pre_delete(self, request, folder):
+        """
+        Perform folder operations prior to deletions. For example, deleting all contents.
+        """
+        for m in folder.members():
+            if m.__class__ == folder.__class__:
+                self.folder_pre_delete(request, m)
+            m.delete()
+
 
 class HookProxy(object):
 

--- a/pinax/documents/models.py
+++ b/pinax/documents/models.py
@@ -158,6 +158,12 @@ class Folder(models.Model):
             FM._default_manager.bulk_create(fm)
             DM._default_manager.bulk_create(dm)
 
+    def delete_url(self):
+        return reverse(
+            "pinax_documents:folder_delete",
+            args=[self.pk]
+        )
+
 
 class Document(models.Model):
 

--- a/pinax/documents/urls.py
+++ b/pinax/documents/urls.py
@@ -19,4 +19,6 @@ urlpatterns = [
         name="folder_detail"),
     url(r"^f/(?P<pk>\d+)/share/$", views.FolderShare.as_view(),
         name="folder_share"),
+    url(r"^f/(?P<pk>\d+)/delete/$", views.FolderDelete.as_view(),
+        name="folder_delete"),
 ]

--- a/pinax/documents/views.py
+++ b/pinax/documents/views.py
@@ -172,6 +172,18 @@ class FolderShare(LoginRequiredMixin,
         return context
 
 
+class FolderDelete(LoginRequiredMixin, DeleteView):
+    model = Folder
+    success_url = reverse_lazy("pinax_documents:document_index")
+    template_name = 'pinax/documents/folder_confirm_delete.html'
+
+    def delete(self, request, *args, **kwargs):
+        hookset.folder_pre_delete(self.request, self.get_object())
+        success_url = super(FolderDelete, self).delete(request, *args, **kwargs)
+        hookset.folder_deleted_message(self.request, self.object)
+        return success_url
+
+
 class DocumentCreate(LoginRequiredMixin, CreateView):
     model = Document
     form_class = DocumentCreateForm


### PR DESCRIPTION
This PR implements folder deletion in a similar fashion to document deletion. The big difference being that folder deletion has to deal with child elements where document deletion does not. To address this additional functionality, this PR adds an extra hookset method implemented as "pre delete" functionality. Also, a test for recursive deletion is included.
