### PR TITLE
Remove django-user-accounts dependency

### DIFF
--- a/pinax/documents/compat.py
+++ b/pinax/documents/compat.py
@@ -4,3 +4,8 @@ try:
 except ImportError:
     # Python 3
     from itertools import zip_longest as izip_longest  # noqa
+
+try:
+    from account.mixins import LoginRequiredMixin
+except ImportError:
+    from django.contrib.auth.mixins import LoginRequiredMixin  # noqa

--- a/pinax/documents/templatetags/pinax_documents_tags.py
+++ b/pinax/documents/templatetags/pinax_documents_tags.py
@@ -1,4 +1,5 @@
 from django.template import Library
+from django.utils.html import conditional_escape
 
 from ..utils import convert_bytes
 
@@ -15,3 +16,13 @@ def can_share(member, user):
 @register.filter
 def readable_bytes(bytes):
     return convert_bytes(bytes)
+
+
+@register.simple_tag
+def user_display(user):
+    try:
+        # Use django-user-accounts display function if available
+        from account.utils import user_display as account_user_display
+        return conditional_escape(account_user_display(user))
+    except ImportError:
+        return conditional_escape(user.username)

--- a/pinax/documents/views.py
+++ b/pinax/documents/views.py
@@ -17,8 +17,7 @@ from django.views.generic.detail import (
 )
 from django.views.generic.edit import FormMixin, ProcessFormView
 
-from account.mixins import LoginRequiredMixin
-
+from .compat import LoginRequiredMixin
 from .conf import settings
 from .forms import (
     ColleagueFolderShareForm,

--- a/runtests.py
+++ b/runtests.py
@@ -17,7 +17,6 @@ DEFAULT_SETTINGS = dict(
         "pinax.documents.tests",
         "pinax.templates",
         "bootstrapform",
-        "account",
     ],
     MIDDLEWARE=[
         "django.contrib.sessions.middleware.SessionMiddleware",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
+import os
+import sys
 from setuptools import find_packages, setup
 
-VERSION = "1.0.1"
+VERSION = "1.0.2"
 LONG_DESCRIPTION = """
 .. image:: http://pinaxproject.com/pinax-design/patches/pinax-documents.svg
     :target: https://pypi.python.org/pypi/pinax-documents/
@@ -48,6 +50,13 @@ Supported Django and Python Versions
 +-----------------+-----+-----+-----+-----+
 """
 
+
+# Publish Helper.
+if sys.argv[-1] == 'publish':
+    os.system('python setup.py sdist bdist_wheel upload')
+    sys.exit()
+
+
 setup(
     author="Pinax Team",
     author_email="team@pinaxprojects.com",
@@ -81,16 +90,14 @@ setup(
     ],
     install_requires=[
         "django>=1.11",
-        "django-appconf>=1.0.1"
+        "django-appconf>=1.0.2"
     ],
     tests_require=[
         "dj-inmemorystorage>=1.4.0",
-        "django-appconf>=1.0.1",
         "django-bootstrap-form>=3.0.0",
         "django-test-plus>=1.0.22",
-        "django-user-accounts>=2.0.3",
         "mock>=2.0.0",
-        "pinax-templates>=1.0.0",
+        "pinax-templates>=2.0.0",
     ],
     test_suite="runtests.runtests",
     zip_safe=False


### PR DESCRIPTION
Use DUA if it is available, but no longer require it.
If using pinax-templates, version 2.0.0+ is required.